### PR TITLE
device: standardize subscriptions

### DIFF
--- a/astarte/device/device.py
+++ b/astarte/device/device.py
@@ -336,11 +336,10 @@ class Device:
             print("Error while connecting: " + str(rc))
 
         self.__is_connected = True
-        client.subscribe(self.__get_base_topic())
+        client.subscribe(f'{self.__get_base_topic()}/control/consumer/properties')
         for k, v in self.__interfaces.items():
             try:
                 if v['ownership'] == 'server':
-                    client.subscribe(f'{self.__get_base_topic()}/{k}')
                     client.subscribe(f'{self.__get_base_topic()}/{k}/#')
             except:
                 # Default is device


### PR DESCRIPTION
- Do not subscribe to device root path
- Subscribe to consumer properties control path
- Do not subscribe to the interface root

See https://github.com/astarte-platform/astarte/issues/568

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>