### PR TITLE
Add support to parametric mappings

### DIFF
--- a/astarte/device/interface.py
+++ b/astarte/device/interface.py
@@ -15,6 +15,7 @@
 from typing import Tuple
 from astarte.device.mapping import Mapping
 from datetime import datetime
+from re import sub, match
 
 DEVICE = "device"
 SERVER = "server"
@@ -104,7 +105,10 @@ class Interface:
         Mapping or None
             The Mapping if found, None otherwise
         """
-        return self.mappings.get(endpoint)
+        for path, mapping in self.mappings.items():
+            regex = sub(r'%{\w+}', r'.+', path)
+            if match(regex + "$", endpoint):
+                return mapping
 
     def validate(self, path: str, payload, timestamp: datetime) -> Tuple[bool, str]:
         """

--- a/tests/test_properties_interface.py
+++ b/tests/test_properties_interface.py
@@ -74,6 +74,12 @@ class UnitTests(unittest.TestCase):
                     "type": "booleanarray",
                     "database_retention_policy": "use_ttl",
                     "database_retention_ttl": 31536000,
+                },
+                {
+                    "endpoint": "/test/%{param}/int",
+                    "type": "integer",
+                    "database_retention_policy": "use_ttl",
+                    "database_retention_ttl": 31536000,
                 }
             ]
         }
@@ -252,3 +258,9 @@ class UnitTests(unittest.TestCase):
         result, msg = self.interface.validate("/test/booleanArray", payload, None)
         self.assertFalse(result)
         self.assertIsNot(msg, "")
+
+    def test_validate_parameter_property(self):
+        payload = 1
+        result, msg = self.interface.validate("/test/parameter-value/int", payload, None)
+        self.assertTrue(result)
+        self.assertIs(msg, "")


### PR DESCRIPTION
Add support to interface mappings with parameters in path.
Parameters are identified by `%{parameterName}`, with each endpoint supporting any number of parameters, so the exact match is replaced with a regex one.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>