### PR TITLE
Add device_id generation

### DIFF
--- a/astarte/device/__init__.py
+++ b/astarte/device/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Ispirata S.r.l.
+# Copyright 2020-2022 SECO Mind S.r.l.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,5 +21,6 @@ from .device import Device
 from .introspection import Introspection
 from .interface import Interface
 from .mapping import Mapping
-from .pairing_handler import register_device_with_jwt_token, register_device_with_private_key
+from .pairing_handler import register_device_with_jwt_token, register_device_with_private_key, generate_device_id, \
+    generate_random_device_id
 from .exceptions import AstarteError, DeviceAlreadyRegisteredError, AuthorizationError, APIError

--- a/astarte/device/pairing_handler.py
+++ b/astarte/device/pairing_handler.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import json
 import requests
 from . import crypto, exceptions
+from base64 import urlsafe_b64encode
+from uuid import UUID, uuid5, uuid4
 
 
 def register_device_with_private_key(device_id, realm, private_key_file,
@@ -63,6 +63,47 @@ def register_device_with_jwt_token(device_id, realm, jwt_token,
     return __register_device(
         device_id, realm, __register_device_headers_with_jwt_token(jwt_token),
         pairing_base_url)
+
+
+def generate_device_id(namespace: UUID, unique_data: str):
+    """
+    Deterministically generate a device Id based on UUID namespace identifier and unique data.
+
+    Parameters
+    ----------
+    namespace: UUID
+        UUID namespace of the device_id
+    unique_data: str
+        device unique data used to generate the device_id
+
+    Returns
+    -------
+    str
+        the generated device Id, using the standard Astarte Device ID encoding (base64 urlencoding without padding).
+
+    """
+
+    device_id = uuid5(namespace=namespace, name=unique_data)
+
+    # encode the device_id, strip down the padding and return it as a string
+    return urlsafe_b64encode(device_id.bytes).replace(b'=', b'').decode("utf-8")
+
+
+def generate_random_device_id():
+    """
+    Quick way to generate a device Id.
+    Pay attention that each time this value is different and the use in production is discouraged.
+
+    Returns
+    -------
+    str
+        the generated device Id, using the standard Astarte Device ID encoding (base64 urlencoding without padding).
+
+    """
+    device_id = uuid4()
+
+    # encode the device_id, strip down the padding and return it as a string
+    return urlsafe_b64encode(device_id.bytes).replace(b'=', b'').decode("utf-8")
 
 
 def obtain_device_certificate(device_id, realm, credentials_secret,

--- a/tests/test_pairing_handler.py
+++ b/tests/test_pairing_handler.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+from uuid import UUID
+from astarte.device import generate_device_id, generate_random_device_id
+
+
+class UnitTests(unittest.TestCase):
+    def test_generate_device_id(self):
+        namespace = UUID("f79ad91f-c638-4889-ae74-9d001a3b4cf8")
+        mac_address = "11:22:33:44:55:66"
+        device_uuid = generate_device_id(namespace=namespace, unique_data=mac_address)
+        target_device_id = "F94uGRPGVDGN6bGzEjtNhw"
+        self.assertEqual(device_uuid, target_device_id)
+
+    def test_generate_random_device_id(self):
+        device_uuid = generate_random_device_id()
+        self.assertIsNotNone(device_uuid)


### PR DESCRIPTION
The current SDK has a function to handle pairing and device registration but lacks the UUID generation feature.

This commit adds two utility functions to `pairing_handler.py`:
- `generate_device_id` returns a reliable device type 5 UUID using a namespace and a unique device-specific value
- `generate_random_device_id` returns a pseudo-random type 4 UUID.

Signed-off-by: Francesco Vaiani <francesco.vaiani@udoo.org>