### PR TITLE
Add documentation publication workflow

### DIFF
--- a/.github/workflows/doc-workflow.yaml
+++ b/.github/workflows/doc-workflow.yaml
@@ -1,0 +1,53 @@
+name: Docs generation for Github Pages
+
+on:
+  push:
+    branches:
+    - 'master'
+    - 'release-*'
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the source
+      - uses: actions/checkout@v2
+        with:
+          path: astarte-device-sdk-python
+      # Checkout the docs repository
+      - uses: actions/checkout@v2
+        with:
+          repository: astarte-platform/docs
+          ssh-key: ${{ secrets.DOCS_DEPLOY_KEY }}
+          path: docs
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        working-directory: ./astarte-device-sdk-python/docs
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine requests paho-mqtt cryptography bson PyJWT sphinx m2r2
+      - name: Generate Javadocs with Sphinx-doc
+        working-directory: ./astarte-device-sdk-python/docs
+        run: |
+          sphinx-apidoc -f -o . ../astarte
+          make html
+      - name: Copy Docs
+        run: |
+          export DOCS_DIRNAME="$(echo ${{ github.ref }} | sed 's,refs/heads/,,' | sed 's/master/snapshot/g' | sed 's/release-//g')/device-sdks/python"
+          rm -rf docs/$DOCS_DIRNAME
+          mkdir -p docs/$DOCS_DIRNAME
+          cp -r astarte-device-sdk-python/docs/_build/html/* docs/$DOCS_DIRNAME/
+      - name: Commit files
+        working-directory: ./docs
+        run: |
+          git config --local user.email "astarte-machine@ispirata.com"
+          git config --local user.name "Astarte Bot"
+          git add .
+          git commit -m "Update Python SDK documentation"
+      - name: Push changes
+        working-directory: ./docs
+        run: |
+          git push origin master

--- a/astarte/device/device.py
+++ b/astarte/device/device.py
@@ -32,8 +32,8 @@ class Device:
     Users should instantiate a Device with the right credentials and connect it to the configured instance to
     start working with it.
 
-    Threading and Concurrency
-    ----------
+    **Threading and Concurrency**
+
     This SDK uses paho-mqtt under the hood to provide Transport connectivity. As such, it is bound by paho-mqtt's behaviors
     in terms of threading. When a Device connects, a new thread is spawned and an event loop is run there to manage all the
     connection events.

--- a/astarte/device/mapping.py
+++ b/astarte/device/mapping.py
@@ -72,34 +72,31 @@ class Mapping:
 
     Notes
     -----
-        Supported data types:
-        =====================
+        **Supported data types**
+
         The following types are supported:
-        * double: A double-precision floating-point number as specified by binary64, by the IEEE 754 standard (NaNs and
-         other non numerical values are not supported).
+
+        * double: A double-precision floating-point number as specified by binary64, by the IEEE 754 standard (NaNs and other non numerical values are not supported).
         * integer: A signed 32 bit integer.
         * boolean: Either true or false, adhering to JSON boolean type.
-        * longinteger: A signed 64 bit integer (please note that longinteger is represented as a string by default in
-         JSON-based APIs.).
+        * longinteger: A signed 64 bit integer (please note that longinteger is represented as a string by default in JSON-based APIs.).
         * string: An UTF-8 string, at most 65536 bytes long.
-        * binaryblob: An arbitrary sequence of any byte that should be shorter than 64 KiB. (binaryblob is represented
-         as a base64 string by default in JSON-based APIs.).
-        * datetime: A UTC timestamp, internally represented as milliseconds since 1st Jan 1970 using a signed 64 bits
-         integer. (datetime is represented as an ISO 8601 string by default in JSON based APIs.)
-        * doublearray, integerarray, booleanarray, longintegerarray, stringarray, binaryblobarray, datetimearray: A list
-         of values, represented as a JSON Array. Arrays can have up to 1024 items and each item must respect the limits
-         of its scalar type (i.e. each string in a stringarray must be at most 65535 bytes long, each binary blob in a
-         binaryblobarray must be shorter than 64 KiB.
+        * binaryblob: An arbitrary sequence of any byte that should be shorter than 64 KiB. (binaryblob is represented as a base64 string by default in JSON-based APIs.).
+        * datetime: A UTC timestamp, internally represented as milliseconds since 1st Jan 1970 using a signed 64 bits integer. (datetime is represented as an ISO 8601 string by default in JSON based APIs.)
+        * doublearray, integerarray, booleanarray, longintegerarray, stringarray, binaryblobarray, datetimearray: A list of values, represented as a JSON Array. Arrays can have up to 1024 items and each item must respect the limits of its scalar type (i.e. each string in a stringarray must be at most 65535 bytes long, each binary blob in a binaryblobarray must be shorter than 64 KiB.
 
-        Quality of Service
-        ==================
+        **Quality of Service**
+
         Data messages QoS is chosen according to mapping settings, such as reliability. Properties are always published using QoS 2.
 
-        INTERFACE TYPE	RELIABILITY	    QOS
-        properties      always unique	2
-        datastream	    unreliable	    0
-        datastream	    guaranteed	    1
-        datastream	    unique	        2
+        ============== ============== ===
+        INTERFACE TYPE RELIABILITY    QOS
+        ============== ============== ===
+        properties     always unique	2
+        datastream	   unreliable	    0
+        datastream	   guaranteed	    1
+        datastream	   unique	        2
+        ============== ============== ===
     """
 
     def __init__(self, mapping_definition: dict, interface_type):

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,15 +10,17 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../astarte'))
 
 
 # -- Project information -----------------------------------------------------
 
 project = 'Astarte Device SDK Python'
-copyright = '2022, SECOMind'
+copyright = '2021-2022, SECOMind'
 author = 'SECOMind'
 
 # The short X.Y version
@@ -56,7 +58,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'bizstyle'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,72 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Astarte Device SDK Python'
+copyright = '2022, SECOMind'
+author = 'SECOMind'
+
+# The short X.Y version
+version = '0.10'
+
+# The full version, including alpha/beta/rc tags
+release = '0.10.0a6'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.napoleon',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.todo',
+    'sphinx.ext.ifconfig',
+    'm2r2',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+
+# -- Extension configuration -------------------------------------------------
+
+# -- Options for todo extension ----------------------------------------------
+
+# If true, `todo` and `todoList` produce output, else they produce nothing.
+todo_include_todos = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+.. Astarte Device SDK Python documentation master file, created by
+   sphinx-quickstart on Mon Mar 14 16:58:11 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Astarte Device SDK Python's documentation!
+=====================================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,8 @@ Welcome to Astarte Device SDK Python's documentation!
    :maxdepth: 2
    :caption: Contents:
 
-
+   modules
+.. mdinclude:: ../README.md
 
 Indices and tables
 ==================

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd


### PR DESCRIPTION
- Add the output files of `sphinx-quickstart`
- Update Sphinx-doc generated files to adapt to our needs
- Add a GitHub action to generate the documentation for the Python SDK
- Update some docstrings for better Sphinx-doc render