### PR TITLE
Avoid adding invalid interface

### DIFF
--- a/astarte/device/interface.py
+++ b/astarte/device/interface.py
@@ -60,10 +60,19 @@ class Interface:
         interface_definition: dict
             An Astarte Interface definition in the form of a Python dictionary. Usually obtained
             by using json.loads on an Interface file.
+
+        Raises
+        ------
+        ValueError
+            if both version_major and version_minor numbers are set to 0
         """
         self.name: str = interface_definition["interface_name"]
         self.version_major: int = interface_definition["version_major"]
         self.version_minor: int = interface_definition["version_minor"]
+
+        if not self.version_major and not self.version_minor:
+            raise ValueError(f"Both Major and Minor versions set to 0 for interface {self.name}")
+
         self.type: str = interface_definition["type"]
         self.ownership = "device"
         if "ownership" in interface_definition:

--- a/tests/test_properties_interface.py
+++ b/tests/test_properties_interface.py
@@ -264,3 +264,14 @@ class UnitTests(unittest.TestCase):
         result, msg = self.interface.validate("/test/parameter-value/int", payload, None)
         self.assertTrue(result)
         self.assertIs(msg, "")
+
+    def test_major_minor_zero_exception(self):
+        bad_interface_json = {
+            "interface_name": "com.astarte.MajorMinorTest",
+            "version_major": 0,
+            "version_minor": 0,
+            "type": "properties",
+            "ownership": "device",
+            "mappings": []
+        }
+        self.assertRaises(ValueError, lambda: Interface(bad_interface_json))


### PR DESCRIPTION
Avoid adding an interface with major and minor version number both at zero adding a check to return a specific error.

Close #25

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>