### PR TITLE
Update interface type check

### DIFF
--- a/astarte/device/device.py
+++ b/astarte/device/device.py
@@ -354,17 +354,12 @@ class Device:
         return interface.is_aggregation_object()
 
     def __is_interface_type_properties(self, interface_name):
-        if interface_name not in self.__interfaces:
+        interface = self.__introspection.get_interface(interface_name)
+        if not interface:
             raise FileNotFoundError(
                 f'Interface {interface_name} not declared in introspection')
 
-        try:
-            if self.__interfaces[interface_name]['type'] == 'properties':
-                return True
-        except KeyError:
-            raise TypeError('Interface \'type\' key must be present')
-
-        return False
+        return interface.is_type_properties()
 
     def __get_base_topic(self):
         return f'{self.__realm}/{self.__device_id}'

--- a/astarte/device/interface.py
+++ b/astarte/device/interface.py
@@ -92,6 +92,16 @@ class Interface:
         """
         return self.ownership == "server"
 
+    def is_type_properties(self):
+        """
+        Check the Interface type
+        Returns
+        -------
+        bool
+            True if type: properties
+        """
+        return self.type == "properties"
+
     def get_mapping(self, endpoint) -> Mapping:
         """
         Retrieve the Mapping with the given endpoint from the Interface

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -3,6 +3,8 @@
 
 import unittest
 import os
+from unittest.mock import MagicMock
+
 from astarte.device import Device
 
 
@@ -21,6 +23,22 @@ class UnitTests(unittest.TestCase):
                     "endpoint": "/test/uno",
                     "type": "integer",
                     "database_retention_policy": "use_ttl",
+                }
+            ]
+        }
+
+        self.property_interface_json = {
+            "interface_name": "com.astarte.PropertyTest",
+            "version_major": 0,
+            "version_minor": 1,
+            "type": "properties",
+            "ownership": "device",
+            "mappings": [
+                {
+                    "endpoint": "/test/int",
+                    "type": "integer",
+                    "database_retention_policy": "use_ttl",
+                    "database_retention_ttl": 31536000,
                 }
             ]
         }
@@ -45,3 +63,8 @@ class UnitTests(unittest.TestCase):
         self.device.add_interface(interface_definition_unique)
         self.assertIs(self.device._get_qos(interface_definition_unique["interface_name"]), 2,
                       msg="qos should be '2' for 'unique' reliability")
+
+    def test_unset_property(self):
+        self.device.add_interface(self.property_interface_json)
+        self.device._send_generic = MagicMock(return_value=None)
+        self.device.unset_property("com.astarte.PropertyTest", "/test/int")


### PR DESCRIPTION
After the last refactoring a function was not updated to the new Device class structure. This breaks the property unset.
- Moved the interface type check to the Interface class.
- Add a test on the `Device.unset_property` function.

Close #35 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>