### PR TITLE
Project Refactor to black and pylint standards

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,21 @@
+name: Code Quality Checks
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Checks
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+        pip install black==23.1.0 pylint==v2.16.2
+    - name: Format check
+      run: black -l 100 --diff --check $(git ls-files 'astarte')
+    - name: Static code analysis
+      run: pylint $(git ls-files 'astarte')

--- a/.pylintrc
+++ b/.pylintrc
@@ -115,6 +115,9 @@ disable=
     format,
     # We anticipate #3512 where it will become optional
     fixme,
+    # Currently the "not callable" error throws false positive warnings
+    # See https://github.com/PyCQA/pylint/issues/1493
+    not-callable,
 
 
 [REPORTS]
@@ -552,6 +555,7 @@ check-str-concat-over-line-jumps=no
 # suggestions which would get split by a code formatter (e.g., black). Will
 # default to the setting for ``max-line-length``.
 #max-line-length-suggestions=
+
 
 [tool.pylint.parameter_documentation]
 accept-no-param-doc = false

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,561 @@
+[MAIN]
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Files or directories to be skipped. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the ignore-list. The
+# regex matches against paths and can be in Posix or Windows format.
+ignore-paths=
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths.
+ignore-patterns=^\.#
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+    pylint.extensions.check_elif,
+    pylint.extensions.bad_builtin,
+    pylint.extensions.docparams,
+    pylint.extensions.for_any_all,
+    pylint.extensions.set_membership,
+    pylint.extensions.code_style,
+    pylint.extensions.overlapping_exceptions,
+    pylint.extensions.typing,
+    pylint.extensions.redefined_variable_type,
+    pylint.extensions.comparison_placement,
+    pylint.extensions.broad_try_clause,
+    pylint.extensions.dict_init_mutate,
+    pylint.extensions.consider_refactoring_into_while_condition,
+    pylint.extensions.comparetozero,
+    pylint.extensions.emptystring,
+    pylint.extensions.no_self_use,
+    pylint.extensions.redefined_loop_name,
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-allow-list=
+
+# Minimum supported python version
+py-version = 3.7.2
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10.0
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint in
+# a server-like mode.
+clear-cache-post-run=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+# confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+    use-symbolic-message-instead,
+    useless-suppression,
+    compare-to-empty-string,
+    no-self-use,
+    redefined-loop-name,
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+
+disable=
+    attribute-defined-outside-init,
+    invalid-name,
+    missing-docstring,
+    protected-access,
+    too-few-public-methods,
+    # handled by black
+    format,
+    # We anticipate #3512 where it will become optional
+    fixme,
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables 'fatal', 'error', 'warning', 'refactor', 'convention'
+# and 'info', which contain the number of messages in each category, as
+# well as 'statement', which is the total number of statements analyzed. This
+# score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Activate the evaluation score.
+score=yes
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=6
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Maximum number of lines in a module
+max-module-lines=2000
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,}$
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style.
+#class-const-rgx=
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,}$
+
+# Regular expression matching correct type variable names
+#typevar-rgx=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring. Use ^(?!__init__$)_ to also check __init__.
+no-docstring-rgx=__.*__
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# List of decorators that define properties, such as abc.abstractproperty.
+property-classes=abc.abstractproperty
+
+
+[TYPECHECK]
+
+# Regex pattern to define which classes are considered mixins if ignore-mixin-
+# members is set to 'yes'
+mixin-class-rgx=.*MixIn
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=SQLObject, optparse.Values, thread._local, _thread._local
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent,argparse.Namespace
+
+# List of decorators that create context managers from functions, such as
+# contextlib.contextmanager.
+contextmanager-decorators=contextlib.contextmanager
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# List of comma separated words that should be considered directives if they
+# appear and the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:,pragma:,# noinspection
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=.pyenchant_pylint_custom_dict.txt
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=2
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args = 9
+
+# Maximum number of locals for function / method body
+max-locals = 19
+
+# Maximum number of return / yield for function / method body
+max-returns=11
+
+# Maximum number of branch for function / method body
+max-branches = 20
+
+# Maximum number of statements in function / method body
+max-statements = 50
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=11
+
+# Maximum number of statements in a try-block
+max-try-statements = 7
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp,__post_init__
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=builtins.Exception
+
+
+[TYPING]
+
+# Set to ``no`` if the app / library does **NOT** need to support runtime
+# introspection of type annotations. If you use type annotations
+# **exclusively** for type checking of an application, you're probably fine.
+# For libraries, evaluate if some users what to access the type hints at
+# runtime first, e.g., through ``typing.get_type_hints``. Applies to Python
+# versions 3.7 - 3.9
+runtime-typing = no
+
+
+[DEPRECATED_BUILTINS]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,input
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[CODE_STYLE]
+
+# Max line length for which to sill emit suggestions. Used to prevent optional
+# suggestions which would get split by a code formatter (e.g., black). Will
+# default to the setting for ``max-line-length``.
+#max-line-length-suggestions=
+
+[tool.pylint.parameter_documentation]
+accept-no-param-doc = false
+accept-no-raise-doc = false
+accept-no-return-doc = false
+accept-no-yields-doc = false
+default-docstring-type = numpy

--- a/astarte/device/__init__.py
+++ b/astarte/device/__init__.py
@@ -21,6 +21,15 @@ from .device import Device
 from .introspection import Introspection
 from .interface import Interface
 from .mapping import Mapping
-from .pairing_handler import register_device_with_jwt_token, register_device_with_private_key, generate_device_id, \
-    generate_random_device_id
-from .exceptions import AstarteError, DeviceAlreadyRegisteredError, AuthorizationError, APIError
+from .pairing_handler import (
+    register_device_with_jwt_token,
+    register_device_with_private_key,
+    generate_device_id,
+    generate_random_device_id,
+)
+from .exceptions import (
+    AstarteError,
+    DeviceAlreadyRegisteredError,
+    AuthorizationError,
+    APIError,
+)

--- a/astarte/device/crypto.py
+++ b/astarte/device/crypto.py
@@ -24,6 +24,23 @@ from datetime import datetime
 
 
 def generate_csr(realm: str, device_id: str, crypto_store_dir: str) -> bytes:
+    """
+    Utility function that generate the csr for the device
+
+    Parameters
+    ----------
+    realm: str
+        The Astarte realm where the device will be registered
+    device_id: str
+        The device ID
+    crypto_store_dir: str
+        Path to the folder where crypto information is stored
+
+    Returns
+    -------
+    bytes
+        The device certificate signing request file
+    """
     key = None
     # Do we need to generate a keypair?
     if not path.exists(path.join(crypto_store_dir, "device.key")):
@@ -73,6 +90,20 @@ def import_device_certificate(client_crt: str, crypto_store_dir: str) -> None:
 
 
 def device_has_certificate(crypto_store_dir: str) -> bool:
+    """
+    Utility function that checks if a certificate is present for the device
+
+    Parameters
+    ----------
+    crypto_store_dir: str
+        Path to the folder where crypto information is stored
+
+    Returns
+    -------
+    bool
+        True if the certificate is present, False otherwise
+
+    """
     cert_path = path.join(crypto_store_dir, "device.crt")
     key_path = path.join(crypto_store_dir, "device.key")
 
@@ -82,6 +113,20 @@ def device_has_certificate(crypto_store_dir: str) -> bool:
 
 
 def certificate_is_valid(crypto_store_dir: str) -> bool:
+    """
+    Utility function that checks the certificate validity
+
+    Parameters
+    ----------
+    crypto_store_dir: str
+        Path to the folder where crypto information are stored
+
+    Returns
+    -------
+    bool
+        True if the certificate is valid, False otherwise.
+
+    """
     cert_path = path.join(crypto_store_dir, "device.crt")
     with open(cert_path, "r") as file:
         data = file.read()

--- a/astarte/device/crypto.py
+++ b/astarte/device/crypto.py
@@ -129,7 +129,7 @@ def certificate_is_valid(crypto_store_dir: str) -> bool:
 
     """
     cert_path = path.join(crypto_store_dir, "device.crt")
-    with open(cert_path, "r") as file:
+    with open(cert_path, "r", encoding="utf-8") as file:
         data = file.read()
     if data:
         try:

--- a/astarte/device/crypto.py
+++ b/astarte/device/crypto.py
@@ -13,14 +13,15 @@
 # limitations under the License.
 
 
+from datetime import datetime
+from os import path
+
+from cryptography import x509
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography import x509
 from cryptography.x509.oid import NameOID
-from cryptography.hazmat.primitives import hashes
-from os import path
-from datetime import datetime
 
 
 def generate_csr(realm: str, device_id: str, crypto_store_dir: str) -> bytes:

--- a/astarte/device/device.py
+++ b/astarte/device/device.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+from __future__ import annotations
 import asyncio
 import collections.abc
 from datetime import datetime
 import os
-from typing import Optional, Callable, Tuple
+from collections.abc import Callable
 
 import bson
 import paho.mqtt.client as mqtt
@@ -73,7 +73,7 @@ class Device:
         credentials_secret: str,
         pairing_base_url: str,
         persistency_dir: str,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
+        loop: asyncio.AbstractEventLoop | None = None,
         ignore_ssl_errors: bool = False,
     ):
         """
@@ -110,16 +110,16 @@ class Device:
         self.__pairing_base_url = pairing_base_url
         self.__persistency_dir = persistency_dir
         self.__credentials_secret = credentials_secret
-        self.__jwt_token: Optional[str] = None
+        self.__jwt_token: str | None = None
         self.__is_crypto_setup = False
         self.__introspection = Introspection()
         self.__is_connected = False
         self.__loop = loop
         self.__ignore_ssl_errors = ignore_ssl_errors
 
-        self.on_connected: Optional[Callable[[Device], None]] = None
-        self.on_disconnected: Optional[Callable[[Device, int], None]] = None
-        self.on_data_received: Optional[Callable[[Device, str, str, object], None]] = None
+        self.on_connected: Callable[Device, None] | None = None
+        self.on_disconnected: Callable[[Device, int], None] | None = None
+        self.on_data_received: Callable[[Device, str, str, object], None] | None = None
 
         # Check if the persistency dir exists
         if not os.path.isdir(persistency_dir):
@@ -269,7 +269,7 @@ class Device:
         interface_name: str,
         interface_path: str,
         payload: object,
-        timestamp: Optional[datetime] = None,
+        timestamp: datetime | None = None,
     ) -> None:
         """
         Sends an individual message to an interface.
@@ -319,7 +319,7 @@ class Device:
         interface_name: str,
         interface_path: str,
         payload: dict,
-        timestamp: Optional[datetime] = None,
+        timestamp: datetime | None = None,
     ) -> None:
         """
         Sends an aggregate message to an interface
@@ -378,7 +378,7 @@ class Device:
             f"{self.__get_base_topic()}/{interface_name}{interface_path}", None, qos=qos
         )
 
-    def __send_generic(self, topic: str, object_payload: Optional[str], qos=2) -> None:
+    def __send_generic(self, topic: str, object_payload: str | None, qos=2) -> None:
         if object_payload:
             payload = bson.dumps(object_payload)
         else:
@@ -529,8 +529,8 @@ class Device:
         interface_name: str,
         interface_path: str,
         payload: object,
-        timestamp: Optional[datetime],
-    ) -> Tuple[bool, str]:
+        timestamp: datetime | None,
+    ) -> tuple[bool, str]:
         """
         Verifies the data corresponds with the interface.
 

--- a/astarte/device/device.py
+++ b/astarte/device/device.py
@@ -13,16 +13,18 @@
 # limitations under the License.
 
 from __future__ import annotations
+
 import asyncio
 import collections.abc
-from datetime import datetime
 import os
+import ssl
 from collections.abc import Callable
+from datetime import datetime
+from urllib.parse import urlparse
 
 import bson
 import paho.mqtt.client as mqtt
-import ssl
-from urllib.parse import urlparse
+
 from astarte.device import crypto, pairing_handler
 from astarte.device.introspection import Introspection
 

--- a/astarte/device/device.py
+++ b/astarte/device/device.py
@@ -31,24 +31,26 @@ class Device:
     """
     Basic class to define an Astarte Device.
 
-    Device represents an Astarte Device. It is the base class used for managing the Device lifecycle and data.
-    Users should instantiate a Device with the right credentials and connect it to the configured instance to
-    start working with it.
+    Device represents an Astarte Device. It is the base class used for managing the Device
+    lifecycle and data. Users should instantiate a Device with the right credentials and connect
+    it to the configured instance to start working with it.
 
     **Threading and Concurrency**
 
-    This SDK uses paho-mqtt under the hood to provide Transport connectivity. As such, it is bound by paho-mqtt's behaviors
-    in terms of threading. When a Device connects, a new thread is spawned and an event loop is run there to manage all the
-    connection events.
+    This SDK uses paho-mqtt under the hood to provide Transport connectivity. As such,
+    it is bound by paho-mqtt's behaviors in terms of threading. When a Device connects,
+    a new thread is spawned and an event loop is run there to manage all the connection events.
 
-    This SDK spares the user from this detail - on the other hand, when configuring callbacks, threading has to be taken into
-    account. When creating a Device, it is possible to specify an asyncio.loop to automatically manage this detail. When a loop
-    is specified, all callbacks will be called in the context of that loop, guaranteeing thread-safety and making sure that
+    This SDK spares the user from this detail - on the other hand, when configuring callbacks,
+    threading has to be taken into account. When creating a Device, it is possible to specify an
+    asyncio.loop() to automatically manage this detail. When a loop is specified, all callbacks
+    will be called in the context of that loop, guaranteeing thread-safety and making sure that
     the user does not have to take any further action beyond consuming the callback.
 
-    When a loop is not specified, callbacks are invoked just as standard Python functions. This inevitably means that the user
-    will have to take into account the fact that the callback will be invoked in the Thread of the MQTT connection. In particular,
-    blocking the execution of that thread might cause deadlocks and, in general, malfunctions in the SDK. For this reason, the
+    When a loop is not specified, callbacks are invoked just as standard Python functions. This
+    inevitably means that the user will have to take into account the fact that the callback will
+    be invoked in the Thread of the MQTT connection. In particular, blocking the execution of
+    that thread might cause deadlocks and, in general, malfunctions in the SDK. For this reason, the
     usage of asyncio is strongly recommended.
 
     Attributes
@@ -56,10 +58,12 @@ class Device:
     on_connected : Callable[[Device], None]
         A function that will be invoked everytime the device successfully connects.
     on_disconnected : Callable[[Device, int], None]
-        A function that will be invoked everytime the device disconnects. The int parameter bears the disconnect reason.
+        A function that will be invoked everytime the device disconnects. The int parameter bears
+        the disconnect reason.
     on_data_received : Callable[[Device, string, string, object], None]
-        A function that will be invoked everytime data is received from Astarte. Parameters are the Device itself, the Interface
-        name, the Interface path, and the payload. The payload will reflect the type defined in the Interface.
+        A function that will be invoked everytime data is received from Astarte. Parameters are
+        the Device itself, the Interface name, the Interface path, and the payload. The payload
+        will reflect the type defined in the Interface.
     """
 
     def __init__(
@@ -80,21 +84,25 @@ class Device:
         realm : str
             The Realm this Device will be connecting against.
         credentials_secret : str
-            The Credentials Secret for this Device. The Device class assumes your Device has already been registered - if that
-            is not the case, you can use either :py:func:`register_device_with_jwt_token` or :py:func:`register_device_with_private_key`.
+            The Credentials Secret for this Device. The Device class assumes your Device has
+            already been registered - if that is not the case, you can use either
+            :py:func:`register_device_with_jwt_token` or
+            :py:func:`register_device_with_private_key`.
         pairing_base_url : str
             The Base URL of Pairing API of the Astarte Instance the Device will connect to.
         persistency_dir : str
-            Path to an existing directory which will be used for holding persistency for this device: certificates, caching and more.
-            It doesn't have to be unique per device, a subdirectory for the given Device ID will be created.
+            Path to an existing directory which will be used for holding persistency for this
+            device: certificates, caching and more. It doesn't have to be unique per device,
+            a subdirectory for the given Device ID will be created.
         loop : asyncio.loop, optional
-            An optional loop which will be used for invoking callbacks. When this is not none, Device will call any specified callback
-            through loop.call_soon_threadsafe, ensuring that the callbacks will be run in thread the loop belongs to. Usually, you want
-            to set this to get_running_loop(). When not sent, callbacks will be invoked as a standard function - keep in mind this means
-            your callbacks might create deadlocks.
+            An optional loop which will be used for invoking callbacks. When this is not none,
+            Device will call any specified callback through loop.call_soon_threadsafe, ensuring
+            that the callbacks will be run in thread the loop belongs to. Usually, you want
+            to set this to get_running_loop(). When not sent, callbacks will be invoked as a
+            standard function - keep in mind this means your callbacks might create deadlocks.
         ignore_ssl_errors: bool (optional)
-            Useful if you're using the Device to connect to a test instance of Astarte with self signed certificates,
-            it is not recommended to leave this `true` in production.
+            Useful if you're using the Device to connect to a test instance of Astarte with
+            self-signed certificates, it is not recommended to leave this `true` in production.
             Defaults to `false`, if `true` the device will ignore SSL errors during connection.
         """
         self.__device_id = device_id
@@ -134,13 +142,14 @@ class Device:
         """
         Adds an Interface to the Device
 
-        This will add an Interface definition to the Device. It has to be called before :py:func:`connect`, as it will be
-        used for building the Device Introspection.
+        This will add an Interface definition to the Device. It has to be called before
+        :py:func:`connect`, as it will be used for building the Device Introspection.
 
         Parameters
         ----------
         interface_definition : dict
-            An Astarte Interface definition in the form of a Python dictionary. Usually obtained by using json.loads on an Interface file.
+            An Astarte Interface definition in the form of a Python dictionary. Usually obtained
+            by using json.loads() on an Interface file.
         """
         self.__introspection.add_interface(interface_definition)
 
@@ -148,8 +157,8 @@ class Device:
         """
         Removes an Interface from the Device
 
-        Removes an Interface definition from the Device. It has to be called before :py:func:`connect`, as it will be
-        used for building the Device Introspection.
+        Removes an Interface definition from the Device. It has to be called before
+        :py:func:`connect`, as it will be used for building the Device Introspection.
 
         Parameters
         ----------
@@ -199,12 +208,12 @@ class Device:
         """
         Connects the Device asynchronously.
 
-        When calling connect, a new connection thread is spawned and the Device will start a connection routine.
-        The function might return before the Device connects: you want to use the on_connected callback to ensure
-        you are notified upon connection.
+        When calling connect, a new connection thread is spawned and the Device will start a
+        connection routine. The function might return before the Device connects: you want to
+        use the on_connected callback to ensure you are notified upon connection.
 
-        In case the Device gets disconnected unexpectedly, it will try to reconnect indefinitely until disconnect()
-        is called.
+        In case the Device gets disconnected unexpectedly, it will try to reconnect indefinitely
+        until disconnect() is called.
         """
         if self.__is_connected:
             return
@@ -237,11 +246,12 @@ class Device:
         """
         Disconnects the Device asynchronously.
 
-        When calling disconnect, the connection thread is requested to terminate the disconnection, and the thread is stopped
-        when the disconnection happens.
-        The function might return before the Device connects: you want to use the on_disconnected callback to ensure
-        you are notified upon connection. When doing so, check the return code parameter: if it is 0, it means the disconnection
-        happened following an explicit disconnection request.
+        When calling disconnect, the connection thread is requested to terminate the
+        disconnection, and the thread is stopped when the disconnection happens.
+        The function might return before the Device connects: you want to use the on_disconnected
+        callback to ensure you are notified upon connection. When doing so, check the return
+        code parameter: if it is 0, it means the disconnection happened following an explicit
+        disconnection request.
         """
         if not self.__is_connected:
             return
@@ -271,14 +281,16 @@ class Device:
         interface_path : str
             The path on the Interface to send data to.
         payload : object
-            The value to be sent. The type should be compatible to the one specified in the interface path.
+            The value to be sent. The type should be compatible to the one specified in the
+            interface path.
         timestamp : datetime, optional
-            If sending a Datastream with explicit_timestamp, you can specify a datetime object which will be registered
-            as the timestamp for the value.
+            If sending a Datastream with explicit_timestamp, you can specify a datetime object
+            which will be registered as the timestamp for the value.
         """
         if self.__is_interface_aggregate(interface_name):
             raise TypeError(
-                f"Interface {interface_name} is an aggregate interface. You should use send_aggregate."
+                f"Interface {interface_name} is an aggregate interface. You should use "
+                f"send_aggregate."
             )
 
         if isinstance(payload, collections.abc.Mapping):
@@ -319,8 +331,8 @@ class Device:
         payload : dict
             A dictionary containing the path:value map for the aggregate.
         timestamp : datetime, optional
-            If the Datastream has explicit_timestamp, you can specify a datetime object which will be registered
-            as the timestamp for the value.
+            If the Datastream has explicit_timestamp, you can specify a datetime object which
+            will be registered as the timestamp for the value.
         """
         if not self.__is_interface_aggregate(interface_name):
             raise TypeError(
@@ -356,7 +368,8 @@ class Device:
         """
         if not self.__is_interface_type_properties(interface_name):
             raise TypeError(
-                f"Interface {interface_name} is a datastream interface. You can only unset a property."
+                f"Interface {interface_name} is a datastream interface. You can only unset a "
+                f"property."
             )
 
         qos = self._get_qos(interface_name)
@@ -427,8 +440,8 @@ class Device:
             os.path.join(self.__persistency_dir, self.__device_id, "crypto")
         ):
             self.__mqtt_client.loop_stop()
-            # If the certificate must be regenerated, old mqtt client is no longer valid as it is bound to the
-            # wrong TLS params and paho does not allow to replace them a second time
+            # If the certificate must be regenerated, old mqtt client is no longer valid as it is
+            # bound to the wrong TLS params and paho does not allow to replace them a second time
             self.__setup_mqtt_client()
             self.connect()
 
@@ -448,7 +461,8 @@ class Device:
         interface_name = topic_tokens[0]
         if not self.__introspection.get_interface(interface_name):
             print(
-                f"Received unexpected message for unregistered interface {interface_name}: {msg.topic}, {msg.payload}"
+                f"Received unexpected message for unregistered interface {interface_name}:"
+                f" {msg.topic}, {msg.payload}"
             )
             return
 
@@ -499,7 +513,8 @@ class Device:
         if not interface:
             raise FileNotFoundError(f"Interface {interface_name} not declared in introspection")
 
-        # When aggregation object there is no need to specify the path as every map have the same QoS
+        # When aggregation object there is no need to specify the path as every map have the same
+        # QoS
         if path:
             mapping = interface.get_mapping(path)
             if not mapping:
@@ -526,10 +541,11 @@ class Device:
         interface_path : str
             The path on the Interface to send data to.
         payload : object
-            The value to be sent. The type should be compatible to the one specified in the interface path.
+            The value to be sent. The type should be compatible to the one specified in the
+            interface path.
         timestamp : datetime, optional
-            If sending a Datastream with explicit_timestamp, you can specify a datetime object which will be registered
-            as the timestamp for the value.
+            If sending a Datastream with explicit_timestamp, you can specify a datetime object
+            which will be registered as the timestamp for the value.
 
         Returns
         -------

--- a/astarte/device/device.py
+++ b/astarte/device/device.py
@@ -29,7 +29,7 @@ from astarte.device import crypto, pairing_handler
 from astarte.device.introspection import Introspection
 
 
-class Device:
+class Device:  # pylint: disable=too-many-instance-attributes
     """
     Basic class to define an Astarte Device.
 

--- a/astarte/device/exceptions.py
+++ b/astarte/device/exceptions.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 class AstarteError(Exception):
     """Base class for Astarte Errors."""
+
     pass
 
+
 class DeviceAlreadyRegisteredError(AstarteError):
-    """Exception raised in case a Device being registered has already been registered.
-    """
+    """Exception raised in case a Device being registered has already been registered."""
+
 
 class AuthorizationError(AstarteError):
     """Exception raised when Astarte APIs refuse authentication.
@@ -29,6 +32,7 @@ class AuthorizationError(AstarteError):
 
     def __init__(self, body):
         self.body = body
+
 
 class APIError(AstarteError):
     """Exception raised when Astarte APIs throw unhandled errors.

--- a/astarte/device/exceptions.py
+++ b/astarte/device/exceptions.py
@@ -16,8 +16,6 @@
 class AstarteError(Exception):
     """Base class for Astarte Errors."""
 
-    pass
-
 
 class DeviceAlreadyRegisteredError(AstarteError):
     """Exception raised in case a Device being registered has already been registered."""

--- a/astarte/device/interface.py
+++ b/astarte/device/interface.py
@@ -137,9 +137,9 @@ class Interface:
 
         Returns
         -------
-        success: bool
+        bool
             Success of the validation operation
-        msg: str
+        str
             Error message if success is False
         """
         # Check the interface has device ownership

--- a/astarte/device/interface.py
+++ b/astarte/device/interface.py
@@ -25,11 +25,13 @@ class Interface:
     """
     Class that represent an Interface definition
 
-    Interfaces are a core concept of Astarte which defines how data is exchanged between Astarte and its peers.
-    They are not to be intended as OOP interfaces, but rather as the following definition:
+    Interfaces are a core concept of Astarte which defines how data is exchanged between Astarte
+    and its peers. They are not to be intended as OOP interfaces, but rather as the following
+    definition:
 
-    In Astarte each interface has an owner, can represent either a continuous data stream or a snapshot of a set
-    of properties, and can be either aggregated into an object or be an independent set of individual members.
+    In Astarte each interface has an owner, can represent either a continuous data stream or a
+    snapshot of a set of properties, and can be either aggregated into an object or be an
+    independent set of individual members.
 
     Attributes
     ----------
@@ -54,8 +56,8 @@ class Interface:
         Parameters
         ----------
         interface_definition: dict
-            An Astarte Interface definition in the form of a Python dictionary. Usually obtained by using json.loads on
-            an Interface file.
+            An Astarte Interface definition in the form of a Python dictionary. Usually obtained
+            by using json.loads on an Interface file.
         """
         self.name: str = interface_definition["interface_name"]
         self.version_major: int = interface_definition["version_major"]

--- a/astarte/device/interface.py
+++ b/astarte/device/interface.py
@@ -116,7 +116,7 @@ class Interface:
             The Mapping if found, None otherwise
         """
         for path, mapping in self.mappings.items():
-            regex = sub(r'%{\w+}', r'.+', path)
+            regex = sub(r"%{\w+}", r".+", path)
             if match(regex + "$", endpoint):
                 return mapping
 
@@ -152,7 +152,10 @@ class Interface:
             return False, f"Path {path} not in the {self.name} interface."
         else:
             if not isinstance(payload, dict):
-                return False, f"The interface {self.name} is aggregate, but the payload is not a dictionary"
+                return (
+                    False,
+                    f"The interface {self.name} is aggregate, but the payload is not a dictionary",
+                )
 
             # Validate all paths
             for k, v in payload.items():
@@ -166,7 +169,10 @@ class Interface:
 
             # Check all elements are present
             for mapping in self.mappings:
-                endpoint = mapping[len(path + "/"):]
+                endpoint = mapping[len(path + "/") :]
                 if endpoint not in payload:
-                    return False, f"Path {mapping} has no value in {self.name} interface."
+                    return (
+                        False,
+                        f"Path {mapping} has no value in {self.name} interface.",
+                    )
             return True, ""

--- a/astarte/device/interface.py
+++ b/astarte/device/interface.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 from __future__ import annotations
-from astarte.device.mapping import Mapping
+
 from datetime import datetime
 from re import sub, match
+
+from astarte.device.mapping import Mapping
 
 DEVICE = "device"
 SERVER = "server"

--- a/astarte/device/interface.py
+++ b/astarte/device/interface.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
+from __future__ import annotations
 from astarte.device.mapping import Mapping
 from datetime import datetime
 from re import sub, match
@@ -122,7 +122,7 @@ class Interface:
             if match(regex + "$", endpoint):
                 return mapping
 
-    def validate(self, path: str, payload, timestamp: datetime) -> Tuple[bool, str]:
+    def validate(self, path: str, payload, timestamp: datetime) -> tuple[bool, str]:
         """
         Interface Data validation
 

--- a/astarte/device/introspection.py
+++ b/astarte/device/introspection.py
@@ -20,10 +20,11 @@ class Introspection:
     """
     Class that represent the introspection of a device.
 
-    The introspection is the list od interfaces that the device declares to the server it is compatible with.
+    The introspection is the list od interfaces that the device declares to the server it is
+    compatible with.
 
-    In any given time a device can have a single interface with a given name, multiple interfaces with the same
-    name but different major/minor are not supported.
+    In any given time a device can have a single interface with a given name, multiple interfaces
+    with the same name but different major/minor are not supported.
     """
 
     def __init__(self):
@@ -33,13 +34,14 @@ class Introspection:
         """
         Adds an Interface to the Introspection
 
-        This will add an Interface definition to the Device. It has to be called before :py:func:`connect`, as it will be
-        used for building the Device Introspection.
+        This will add an Interface definition to the Device. It has to be called before
+        :py:func:`connect`, as it will be used for building the Device Introspection.
 
         Parameters
         ----------
         interface_definition : dict
-            An Astarte Interface definition in the form of a Python dictionary. Usually obtained by using json.loads on an Interface file.
+            An Astarte Interface definition in the form of a Python dictionary. Usually obtained
+            by using json.loads() on an Interface file.
         """
         interface = Interface(interface_definition)
         self.__interfaces_list[interface.name] = interface
@@ -48,8 +50,8 @@ class Introspection:
         """
         Removes an Interface from the Introspection
 
-        Removes an Interface definition from the Device. It has to be called before :py:func:`connect`, as it will be
-        used for building the Device Introspection.
+        Removes an Interface definition from the Device. It has to be called before
+        :py:func:`connect`, as it will be used for building the Device Introspection.
 
         Parameters
         ----------

--- a/astarte/device/introspection.py
+++ b/astarte/device/introspection.py
@@ -78,6 +78,8 @@ class Introspection:
         if interface_name in self.__interfaces_list:
             return self.__interfaces_list[interface_name]
 
+        return None
+
     def get_all_interfaces(self) -> list[Interface]:
         """
         Retrieve all the list of all Interfaces in Device's Introspection

--- a/astarte/device/introspection.py
+++ b/astarte/device/introspection.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional, List
+from __future__ import annotations
 
 from astarte.device.interface import Interface
 
@@ -61,7 +61,7 @@ class Introspection:
         if interface_name in self.__interfaces_list:
             del self.__interfaces_list[interface_name]
 
-    def get_interface(self, interface_name: str) -> Optional[Interface]:
+    def get_interface(self, interface_name: str) -> Interface | None:
         """
         Retrieve an Interface definition from the Introspection
 
@@ -78,7 +78,7 @@ class Introspection:
         if interface_name in self.__interfaces_list:
             return self.__interfaces_list[interface_name]
 
-    def get_all_interfaces(self) -> List[Interface]:
+    def get_all_interfaces(self) -> list[Interface]:
         """
         Retrieve all the list of all Interfaces in Device's Introspection
 
@@ -89,7 +89,7 @@ class Introspection:
         """
         return self.__interfaces_list.values()
 
-    def get_all_server_owned_interfaces(self) -> List[Interface]:
+    def get_all_server_owned_interfaces(self) -> list[Interface]:
         """
         Retrieve all the list of all Interfaces in Device's Introspection with server ownership
 

--- a/astarte/device/introspection.py
+++ b/astarte/device/introspection.py
@@ -25,6 +25,7 @@ class Introspection:
     In any given time a device can have a single interface with a given name, multiple interfaces with the same
     name but different major/minor are not supported.
     """
+
     def __init__(self):
         self.__interfaces_list = {}
 
@@ -95,4 +96,9 @@ class Introspection:
         list
             The list of all Interfaces in the Introspection that have ownership "server"
         """
-        return list(filter(lambda interface: interface.is_server_owned(), self.__interfaces_list.values()))
+        return list(
+            filter(
+                lambda interface: interface.is_server_owned(),
+                self.__interfaces_list.values(),
+            )
+        )

--- a/astarte/device/mapping.py
+++ b/astarte/device/mapping.py
@@ -17,6 +17,7 @@ from math import isfinite
 from typing import Union, List
 from datetime import datetime
 
+# Astarte Types definition
 IntList = List[int]
 FloatList = List[float]
 StringList = List[str]
@@ -144,17 +145,19 @@ class Mapping:
     def validate(self, payload: MapType, timestamp: datetime) -> tuple[bool, str]:
         """
         Mapping data validation
+
         Parameters
         ----------
-        payload: object
+        payload: MapType
             Data to validate
         timestamp: datetime or None
             Timestamp associated to the payload
+
         Returns
         -------
-        success: bool
+        bool
             Success of the validation operation
-        msg: str
+        str
             Error message if success is False
         """
         # Check if the interface has explicit_timestamp when a timestamp is given (and viceversa)

--- a/astarte/device/mapping.py
+++ b/astarte/device/mapping.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 from math import isfinite
-from typing import Union, List, Tuple
+from typing import Union, List
 from datetime import datetime
 
 IntList = List[int]
@@ -140,7 +141,7 @@ class Mapping:
             else:
                 self.reliability = 0
 
-    def validate(self, payload: MapType, timestamp: datetime) -> Tuple[bool, str]:
+    def validate(self, payload: MapType, timestamp: datetime) -> tuple[bool, str]:
         """
         Mapping data validation
         Parameters

--- a/astarte/device/mapping.py
+++ b/astarte/device/mapping.py
@@ -23,7 +23,19 @@ BsonList = List[bytes]
 BoolList = List[bool]
 DatetimeList = List[datetime]
 MapType = Union[
-    int, float, str, bytes, bool, datetime, IntList, FloatList, StringList, BsonList, BoolList, DatetimeList]
+    int,
+    float,
+    str,
+    bytes,
+    bool,
+    datetime,
+    IntList,
+    FloatList,
+    StringList,
+    BsonList,
+    BoolList,
+    DatetimeList,
+]
 
 """ Mapping type to python type mapping"""
 type_strings = {
@@ -40,15 +52,11 @@ type_strings = {
     "stringarray": list,
     "binaryblobarray": list,
     "booleanarray": list,
-    "datetimearray": list
+    "datetimearray": list,
 }
 
 """ Mapping quality of service """
-QOS_MAP = {
-    "unreliable": 0,
-    "guaranteed": 1,
-    "unique": 2
-}
+QOS_MAP = {"unreliable": 0, "guaranteed": 1, "unique": 2}
 
 
 class Mapping:
@@ -143,7 +151,10 @@ class Mapping:
             return False, f"It's not possible to set the timestamp for {self.endpoint}"
         # Check the type of data is valid for that endpoint
         if not isinstance(payload, self.__actual_type):
-            return False, f"{self.endpoint} is {self.type} but {type(payload)} was provided"
+            return (
+                False,
+                f"{self.endpoint} is {self.type} but {type(payload)} was provided",
+            )
         # Must return False when trying to send an integer outside -2147483648 to 2147483647 interval.
         if self.type == "integer" and not -2147483648 <= payload <= 2147483647:
             return False, f"Value out of int32 range for {self.endpoint}"
@@ -157,9 +168,14 @@ class Mapping:
                 return False, f"Type incoherence in payload elements"
             subtype: type = type_strings.get(self.type.replace("array", ""))
             if not isinstance(payload[0], subtype):
-                return False, f"{self.endpoint} is {self.type} but {type(payload)} was provided"
+                return (
+                    False,
+                    f"{self.endpoint} is {self.type} but {type(payload)} was provided",
+                )
             # Must return False when trying to send an integer outside -2147483648 to 2147483647 interval.
-            if self.type == "integerarray" and any(elem < -2147483648 or elem > 2147483647 for elem in payload):
+            if self.type == "integerarray" and any(
+                elem < -2147483648 or elem > 2147483647 for elem in payload
+            ):
                 return False, f"Value out of int32 range for {self.endpoint}"
             # Must return False when trying to send a double value which is not a number
             if self.type == "doublearray" and any(not isfinite(elem) for elem in payload):

--- a/astarte/device/mapping.py
+++ b/astarte/device/mapping.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 from __future__ import annotations
+
+from datetime import datetime
 from math import isfinite
 from typing import Union, List
-from datetime import datetime
 
 # Astarte Types definition
 IntList = List[int]

--- a/astarte/device/mapping.py
+++ b/astarte/device/mapping.py
@@ -62,10 +62,12 @@ QOS_MAP = {"unreliable": 0, "guaranteed": 1, "unique": 2}
 class Mapping:
     """
     Class that represent a data Mapping
-    Mappings are designed around REST controller semantics: each mapping describes an endpoint which is resolved to a
-    path, it is strongly typed, and can have additional options. Just like in REST controllers, Endpoints can be
-    parametrized to build REST-like collection and trees. Parameters are identified by %{parameterName}, with each
-    endpoint supporting any number of parameters (see `Limitations <https://docs.astarte-platform.org/snapshot/030-interface.html#limitations>`_).
+    Mappings are designed around REST controller semantics: each mapping describes an endpoint
+    which is resolved to a path, it is strongly typed, and can have additional options. Just like
+    in REST controllers, Endpoints can be parametrized to build REST-like collection and trees.
+    Parameters are identified by %{parameterName}, with each endpoint supporting any number of
+    parameters (see
+    `Limitations <https://docs.astarte-platform.org/snapshot/030-interface.html#limitations>`_).
 
     Attributes
     ----------
@@ -84,18 +86,28 @@ class Mapping:
 
         The following types are supported:
 
-        * double: A double-precision floating-point number as specified by binary64, by the IEEE 754 standard (NaNs and other non numerical values are not supported).
+        * double: A double-precision floating-point number as specified by binary64, by the IEEE
+        754 standard (NaNs and other non-numerical values are not supported).
         * integer: A signed 32 bit integer.
         * boolean: Either true or false, adhering to JSON boolean type.
-        * longinteger: A signed 64 bit integer (please note that longinteger is represented as a string by default in JSON-based APIs.).
+        * longinteger: A signed 64-bit integer (please note that longinteger is represented as a
+        string by default in JSON-based APIs.).
         * string: An UTF-8 string, at most 65536 bytes long.
-        * binaryblob: An arbitrary sequence of any byte that should be shorter than 64 KiB. (binaryblob is represented as a base64 string by default in JSON-based APIs.).
-        * datetime: A UTC timestamp, internally represented as milliseconds since 1st Jan 1970 using a signed 64 bits integer. (datetime is represented as an ISO 8601 string by default in JSON based APIs.)
-        * doublearray, integerarray, booleanarray, longintegerarray, stringarray, binaryblobarray, datetimearray: A list of values, represented as a JSON Array. Arrays can have up to 1024 items and each item must respect the limits of its scalar type (i.e. each string in a stringarray must be at most 65535 bytes long, each binary blob in a binaryblobarray must be shorter than 64 KiB.
+        * binaryblob: An arbitrary sequence of any byte that should be shorter than 64 KiB. (
+        binaryblob is represented as a base64 string by default in JSON-based APIs.).
+        * datetime: A UTC timestamp, internally represented as milliseconds since 1st Jan 1970
+        using a signed 64 bits integer. (datetime is represented as an ISO 8601 string by default
+        in JSON based APIs.)
+        * doublearray, integerarray, booleanarray, longintegerarray, stringarray,
+        binaryblobarray, datetimearray: A list of values, represented as a JSON Array.
+        Arrays can have up to 1024 items and each item must respect the limits of its scalar type
+        (i.e. each string in a stringarray must be at most 65535 bytes long, each binary blob in
+        a binaryblobarray must be shorter than 64 KiB.)
 
         **Quality of Service**
 
-        Data messages QoS is chosen according to mapping settings, such as reliability. Properties are always published using QoS 2.
+        Data messages QoS is chosen according to mapping settings, such as reliability.
+        Properties are always published using QoS 2.
 
         ============== ============== ===
         INTERFACE TYPE RELIABILITY    QOS
@@ -112,8 +124,8 @@ class Mapping:
         Parameters
         ----------
         mapping_definition: dict
-            Mapping from the mappings array of an Astarte Interface definition in the form of a Python dictionary.
-            Usually obtained by using json.loads on an Interface file.
+            Mapping from the mappings array of an Astarte Interface definition in the form of a
+            Python dictionary. Usually obtained by using json.loads() on an Interface file.
         interface_type:
             Type of the parent Interface, used to determine the default reliability
         """
@@ -155,7 +167,8 @@ class Mapping:
                 False,
                 f"{self.endpoint} is {self.type} but {type(payload)} was provided",
             )
-        # Must return False when trying to send an integer outside -2147483648 to 2147483647 interval.
+        # Must return False when trying to send an integer outside -2147483648 to 2147483647
+        # interval.
         if self.type == "integer" and not -2147483648 <= payload <= 2147483647:
             return False, f"Value out of int32 range for {self.endpoint}"
         # Must return False when trying to send a double value which is not a number
@@ -172,7 +185,8 @@ class Mapping:
                     False,
                     f"{self.endpoint} is {self.type} but {type(payload)} was provided",
                 )
-            # Must return False when trying to send an integer outside -2147483648 to 2147483647 interval.
+            # Must return False when trying to send an integer outside -2147483648 to 2147483647
+            # interval.
             if self.type == "integerarray" and any(
                 elem < -2147483648 or elem > 2147483647 for elem in payload
             ):

--- a/astarte/device/pairing_handler.py
+++ b/astarte/device/pairing_handler.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List
 
+from __future__ import annotations
 import requests
 from . import crypto, exceptions
 from base64 import urlsafe_b64encode
@@ -220,7 +220,7 @@ def __register_device_headers_with_jwt_token(jwt_token: str) -> dict:
 def __generate_token(
     private_key_file: str,
     type: str = "appengine",
-    auth_paths: List[str] = [".*::.*"],
+    auth_paths: list[str] = [".*::.*"],
     expiry: int = 30,
 ) -> str:
     import datetime

--- a/astarte/device/pairing_handler.py
+++ b/astarte/device/pairing_handler.py
@@ -13,10 +13,15 @@
 # limitations under the License.
 
 from __future__ import annotations
-import requests
-from . import crypto, exceptions
+
+import datetime
 from base64 import urlsafe_b64encode
 from uuid import UUID, uuid5, uuid4
+
+import jwt
+import requests
+
+from . import crypto, exceptions
 
 
 def register_device_with_private_key(
@@ -379,8 +384,6 @@ def __generate_token(
     str
         The generated token
     """
-    import datetime
-    import jwt
 
     api_claims = {
         "appengine": "a_aea",

--- a/astarte/device/pairing_handler.py
+++ b/astarte/device/pairing_handler.py
@@ -19,8 +19,9 @@ from base64 import urlsafe_b64encode
 from uuid import UUID, uuid5, uuid4
 
 
-def register_device_with_private_key(device_id: str, realm: str, private_key_file: str,
-                                     pairing_base_url: str) -> str:
+def register_device_with_private_key(
+    device_id: str, realm: str, private_key_file: str, pairing_base_url: str
+) -> str:
     """
     Registers a Device against an Astarte instance/realm with a Private Key
 
@@ -38,14 +39,20 @@ def register_device_with_private_key(device_id: str, realm: str, private_key_fil
         The Base URL of Pairing API of the Astarte Instance the Device will be registered in.
     """
     return __register_device(
-        device_id, realm,
+        device_id,
+        realm,
         __register_device_headers_with_private_key(private_key_file),
-        pairing_base_url)
+        pairing_base_url,
+    )
 
 
-def register_device_with_jwt_token(device_id: str, realm: str, jwt_token: str,
-                                   pairing_base_url: str,
-                                   ignore_ssl_errors: bool = False) -> str:
+def register_device_with_jwt_token(
+    device_id: str,
+    realm: str,
+    jwt_token: str,
+    pairing_base_url: str,
+    ignore_ssl_errors: bool = False,
+) -> str:
     """
     Registers a Device against an Astarte instance/realm with a JWT Token
 
@@ -67,8 +74,12 @@ def register_device_with_jwt_token(device_id: str, realm: str, jwt_token: str,
         Defaults to `false`, if `true` SSL errors will be ignored when registering a device.
     """
     return __register_device(
-        device_id, realm, __register_device_headers_with_jwt_token(jwt_token),
-        pairing_base_url, ignore_ssl_errors)
+        device_id,
+        realm,
+        __register_device_headers_with_jwt_token(jwt_token),
+        pairing_base_url,
+        ignore_ssl_errors,
+    )
 
 
 def generate_device_id(namespace: UUID, unique_data: str) -> str:
@@ -92,7 +103,7 @@ def generate_device_id(namespace: UUID, unique_data: str) -> str:
     device_id = uuid5(namespace=namespace, name=unique_data)
 
     # encode the device_id, strip down the padding and return it as a string
-    return urlsafe_b64encode(device_id.bytes).replace(b'=', b'').decode("utf-8")
+    return urlsafe_b64encode(device_id.bytes).replace(b"=", b"").decode("utf-8")
 
 
 def generate_random_device_id() -> str:
@@ -109,40 +120,52 @@ def generate_random_device_id() -> str:
     device_id = uuid4()
 
     # encode the device_id, strip down the padding and return it as a string
-    return urlsafe_b64encode(device_id.bytes).replace(b'=', b'').decode("utf-8")
+    return urlsafe_b64encode(device_id.bytes).replace(b"=", b"").decode("utf-8")
 
 
-def obtain_device_certificate(device_id: str, realm: str, credentials_secret: str,
-                              pairing_base_url: str, crypto_store_dir: str,
-                              ignore_ssl_errors: bool) -> None:
+def obtain_device_certificate(
+    device_id: str,
+    realm: str,
+    credentials_secret: str,
+    pairing_base_url: str,
+    crypto_store_dir: str,
+    ignore_ssl_errors: bool,
+) -> None:
     # Get a CSR first
     csr = crypto.generate_csr(realm, device_id, crypto_store_dir)
     # Prepare the Pairing API request
-    headers = {'Authorization': f'Bearer {credentials_secret}'}
-    data = {'data': {'csr': csr.decode('ascii')}}
+    headers = {"Authorization": f"Bearer {credentials_secret}"}
+    data = {"data": {"csr": csr.decode("ascii")}}
 
     res = requests.post(
-        f'{pairing_base_url}/v1/{realm}/devices/{device_id}/protocols/astarte_mqtt_v1/credentials',
+        f"{pairing_base_url}/v1/{realm}/devices/{device_id}/protocols/astarte_mqtt_v1/credentials",
         json=data,
         headers=headers,
-        verify=not ignore_ssl_errors)
+        verify=not ignore_ssl_errors,
+    )
     if res.status_code == 401 or res.status_code == 403:
         raise exceptions.AuthorizationError(res.json())
     elif res.status_code != 201:
         raise exceptions.APIError(res.json())
 
-    crypto.import_device_certificate(res.json()['data']['client_crt'],
-                              crypto_store_dir)
+    crypto.import_device_certificate(res.json()["data"]["client_crt"], crypto_store_dir)
 
 
-def obtain_device_transport_information(device_id: str, realm: str, credentials_secret: str,
-                                        pairing_base_url: str, ignore_ssl_errors: bool) -> dict:
+def obtain_device_transport_information(
+    device_id: str,
+    realm: str,
+    credentials_secret: str,
+    pairing_base_url: str,
+    ignore_ssl_errors: bool,
+) -> dict:
     # Prepare the Pairing API request
-    headers = {'Authorization': f'Bearer {credentials_secret}'}
+    headers = {"Authorization": f"Bearer {credentials_secret}"}
 
-    res = requests.get(f'{pairing_base_url}/v1/{realm}/devices/{device_id}',
-                       headers=headers,
-                       verify=not ignore_ssl_errors)
+    res = requests.get(
+        f"{pairing_base_url}/v1/{realm}/devices/{device_id}",
+        headers=headers,
+        verify=not ignore_ssl_errors,
+    )
     if res.status_code == 401 or res.status_code == 403:
         raise exceptions.AuthorizationError(res.json())
     elif res.status_code != 200:
@@ -151,14 +174,21 @@ def obtain_device_transport_information(device_id: str, realm: str, credentials_
     return res.json()["data"]
 
 
-def __register_device(device_id: str, realm: str, headers: dict, pairing_base_url: str,
-                      ignore_ssl_errors: bool) -> str:
-    data = {'data': {'hw_id': device_id}}
+def __register_device(
+    device_id: str,
+    realm: str,
+    headers: dict,
+    pairing_base_url: str,
+    ignore_ssl_errors: bool,
+) -> str:
+    data = {"data": {"hw_id": device_id}}
 
-    res = requests.post(f'{pairing_base_url}/v1/{realm}/agent/devices',
-                        json=data,
-                        headers=headers,
-                        verify=not ignore_ssl_errors)
+    res = requests.post(
+        f"{pairing_base_url}/v1/{realm}/agent/devices",
+        json=data,
+        headers=headers,
+        verify=not ignore_ssl_errors,
+    )
     if res.status_code == 401 or res.status_code == 403:
         raise exceptions.AuthorizationError(res.json())
     elif res.status_code == 422:
@@ -166,37 +196,38 @@ def __register_device(device_id: str, realm: str, headers: dict, pairing_base_ur
     elif res.status_code != 201:
         raise exceptions.APIError(res.json())
 
-    return res.json()['data']['credentials_secret']
+    return res.json()["data"]["credentials_secret"]
 
 
 def __register_device_headers_with_private_key(private_key_file) -> dict:
     headers = {}
     try:
-        headers[
-            'Authorization'] = f'Bearer {__generate_token(private_key_file, type="pairing")}'
+        headers["Authorization"] = f'Bearer {__generate_token(private_key_file, type="pairing")}'
         return headers
     except:
-        raise TypeError(
-            "Supplied Realm Key could not be used to generate a valid Token.")
+        raise TypeError("Supplied Realm Key could not be used to generate a valid Token.")
 
 
 def __register_device_headers_with_jwt_token(jwt_token: str) -> dict:
-    return {'Authorization': f'Bearer {jwt_token}'}
+    return {"Authorization": f"Bearer {jwt_token}"}
 
 
 # This throws FileNotFoundError if the private key does not exist
-def __generate_token(private_key_file: str,
-                     type: str = "appengine",
-                     auth_paths: List[str] = [".*::.*"],
-                     expiry: int = 30) -> str:
+def __generate_token(
+    private_key_file: str,
+    type: str = "appengine",
+    auth_paths: List[str] = [".*::.*"],
+    expiry: int = 30,
+) -> str:
     import datetime
     import jwt
+
     api_claims = {
         "appengine": "a_aea",
         "realm": "a_rma",
         "housekeeping": "a_ha",
         "channels": "a_ch",
-        "pairing": "a_pa"
+        "pairing": "a_pa",
     }
 
     with open(private_key_file, "r") as pk:

--- a/astarte/device/pairing_handler.py
+++ b/astarte/device/pairing_handler.py
@@ -24,6 +24,8 @@ import requests
 
 from . import crypto, exceptions
 
+DEFAULT_TIMEOUT = 30
+
 
 def register_device_with_private_key(
     device_id: str,
@@ -195,6 +197,7 @@ def obtain_device_certificate(
         json=data,
         headers=headers,
         verify=not ignore_ssl_errors,
+        timeout=DEFAULT_TIMEOUT,
     )
     if res.status_code in {http.HTTPStatus.UNAUTHORIZED, http.HTTPStatus.FORBIDDEN}:
         raise exceptions.AuthorizationError(res.json())
@@ -247,6 +250,7 @@ def obtain_device_transport_information(
         f"{pairing_base_url}/v1/{realm}/devices/{device_id}",
         headers=headers,
         verify=not ignore_ssl_errors,
+        timeout=DEFAULT_TIMEOUT,
     )
     if res.status_code in {http.HTTPStatus.UNAUTHORIZED, http.HTTPStatus.FORBIDDEN}:
         raise exceptions.AuthorizationError(res.json())
@@ -300,6 +304,7 @@ def __register_device(
         json=data,
         headers=headers,
         verify=not ignore_ssl_errors,
+        timeout=DEFAULT_TIMEOUT,
     )
     if res.status_code in {http.HTTPStatus.UNAUTHORIZED, http.HTTPStatus.FORBIDDEN}:
         raise exceptions.AuthorizationError(res.json())

--- a/astarte/device/pairing_handler.py
+++ b/astarte/device/pairing_handler.py
@@ -34,7 +34,8 @@ def register_device_with_private_key(
     realm : str
         The Realm in which to register the Device.
     private_key_file : str
-        Path to the Private Key file for the Realm. It will be used to Authenticate against Pairing API.
+        Path to the Private Key file for the Realm. It will be used to Authenticate against
+        Pairing API.
     pairing_base_url : str
         The Base URL of Pairing API of the Astarte Instance the Device will be registered in.
     """
@@ -65,11 +66,12 @@ def register_device_with_jwt_token(
     realm : str
         The Realm in which to register the Device.
     jwt_token : str
-        A JWT Token to Authenticate against Pairing API. The token must have access to Pairing API and to the agent API paths.
+        A JWT Token to Authenticate against Pairing API. The token must have access to Pairing
+        API and to the agent API paths.
     pairing_base_url : str
         The Base URL of Pairing API of the Astarte Instance the Device will be registered in.
     ignore_ssl_errors: bool
-        Useful if you're registering a device into a test instance of Astarte with self signed
+        Useful if you're registering a device into a test instance of Astarte with self-signed
         certificates. It is not recommended to leave this `true` in production.
         Defaults to `false`, if `true` SSL errors will be ignored when registering a device.
     """
@@ -96,7 +98,8 @@ def generate_device_id(namespace: UUID, unique_data: str) -> str:
     Returns
     -------
     str
-        the generated device Id, using the standard Astarte Device ID encoding (base64 urlencoding without padding).
+        the generated device Id, using the standard Astarte Device ID encoding (base64
+        urlencoding without padding).
 
     """
 
@@ -114,7 +117,8 @@ def generate_random_device_id() -> str:
     Returns
     -------
     str
-        the generated device Id, using the standard Astarte Device ID encoding (base64 urlencoding without padding).
+        the generated device Id, using the standard Astarte Device ID encoding (base64
+        urlencoding without padding).
 
     """
     device_id = uuid4()


### PR DESCRIPTION
- Reformat with Black
- Add the `pylintrc` suggested by the Python Code Quality Authority with minor edits to ensure docstrings
- Fix line too long pylint warning
- Adapt type hinting convention to pylint standards
- Fix docstrings
- Fix import order
- Fix warnings in the code
- Add timeout to `requests` calls
- Add `pylint` and `black` to the CI

Close #28 