### PR TITLE
Add retry in github action for e2e test step

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -64,7 +64,11 @@ jobs:
           source venv/bin/activate
           python3 -m pip install -e .[e2e]
       - name: Run test
-        run: |
-          source venv/bin/activate
-          export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-          python3 e2etest/main.py
+        uses: nick-fields/retry@v2
+        with:
+          timeout_seconds: 30
+          max_attempts: 2
+          command: |
+            source venv/bin/activate
+            export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+            python3 e2etest/main.py


### PR DESCRIPTION
Retries once running the end-to-end tests.
It hopes to prevent failures due to a connection problem with the astarte cluster.
The added overhead is quite small, as the timeout for the step is set to 30 seconds.
Closes #50 