### PR TITLE
enable pylint docstrings check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -94,6 +94,7 @@ enable=
     compare-to-empty-string,
     no-self-use,
     redefined-loop-name,
+    consider-using-augmented-assign
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
@@ -106,10 +107,8 @@ enable=
 # --disable=W"
 
 disable=
-    attribute-defined-outside-init,
     invalid-name,
-    missing-docstring,
-    protected-access,
+    missing-module-docstring,
     too-few-public-methods,
     # handled by black
     format,

--- a/astarte/device/crypto.py
+++ b/astarte/device/crypto.py
@@ -83,6 +83,17 @@ def generate_csr(realm: str, device_id: str, crypto_store_dir: str) -> bytes:
 
 
 def import_device_certificate(client_crt: str, crypto_store_dir: str) -> None:
+    """
+    Deserialize a client certificate and store the public information permanently in the file system
+
+    Parameters
+    ----------
+    client_crt: str
+        Serialized client certificate
+    crypto_store_dir: str
+        Directory where to store the public bytes of the certificate
+
+    """
     certificate = x509.load_pem_x509_certificate(client_crt.encode("ascii"), default_backend())
 
     # Store the certificate

--- a/astarte/device/device.py
+++ b/astarte/device/device.py
@@ -137,6 +137,9 @@ class Device:  # pylint: disable=too-many-instance-attributes
         self.__setup_mqtt_client()
 
     def __setup_mqtt_client(self) -> None:
+        """
+        Utility function used to setup an MQTT client
+        """
         self.__mqtt_client = mqtt.Client()
         self.__mqtt_client.on_connect = self.__on_connect
         self.__mqtt_client.on_disconnect = self.__on_disconnect
@@ -235,6 +238,9 @@ class Device:  # pylint: disable=too-many-instance-attributes
         return self.__device_id
 
     def __setup_crypto(self) -> None:
+        """
+        Utility function used to setup cytptography
+        """
         if self.__is_crypto_setup:
             return
 
@@ -461,7 +467,20 @@ class Device:  # pylint: disable=too-many-instance-attributes
             f"{self.__get_base_topic()}/{interface_name}{interface_path}", None, qos=qos
         )
 
-    def __send_generic(self, topic: str, object_payload: dict | None, qos=2) -> None:
+    def __send_generic(self, topic: str, object_payload: dict | None, qos: int = 2) -> None:
+        """
+        Utility function used to publish a generic payload to a MQTT topic
+
+        Parameters
+        ----------
+        topic: str
+            The MQTT topic on which to publish the payload
+        object_payload: dict | None
+            The payload to publish
+        qos: int
+            The QoS to use for the publish
+
+        """
         if object_payload:
             payload = bson.dumps(object_payload)
         else:


### PR DESCRIPTION
Pylint was not checking that all functions/classes had a docstring.
This PR enables this check together with a couple of others.