### PR TITLE
Improve workflows for thrusted publishing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,13 +38,6 @@ jobs:
         pip install setuptools wheel twine
     - name: Build dist
       run: python setup.py sdist bdist_wheel
-    # Publish only on tags, and for the 3.11 build
-    - name: Publish package
-      if: startsWith(github.ref, 'refs/tags/v') && github.event_name == 'create' && matrix.python-version == '3.11'
-      uses: pypa/gh-action-pypi-publish@v1.8.10
-      with:
-        user: __token__
-        password: ${{ secrets.PIP_API_TOKEN }}
   tests:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,41 @@
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: PyPI publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    name: Publish release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Python dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build distribution
+      run: python setup.py sdist bdist_wheel
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
A token is not required for trusted publishing.
Publishing is in its own workflow.