### PR TITLE
Compatibility with paho 2+

### DIFF
--- a/astarte/device/device_mqtt.py
+++ b/astarte/device/device_mqtt.py
@@ -308,7 +308,7 @@ class DeviceMqtt(Device):
             return
 
         self.__mqtt_client.disconnect()
-        self.__mqtt_client.loop_stop(force=False)
+        self.__mqtt_client.loop_stop()
 
     def is_connected(self) -> bool:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ license = {text = "Apache-2.0"}
 dynamic = ["version"]
 dependencies = [
     "requests>=2.25.1",
-    "paho-mqtt==1.6.1",
+    "paho-mqtt>=1.3.1",
     "cryptography>=3.2.1",
     "bson>=0.5.5",
     "PyJWT>=1.7.0",


### PR DESCRIPTION
Moves forward in https://github.com/astarte-platform/astarte-device-sdk-python/issues/173.