### PR TITLE
Remove workaround for old astarte versions

### DIFF
--- a/astarte/device/device.py
+++ b/astarte/device/device.py
@@ -63,18 +63,6 @@ class Device(ABC):
         self._on_data_received: Callable[[Device, str, str, object], None] | None = None
         self._on_disconnected: Callable[[Device, int], None] | None = None
         self._loop = None
-        self._disable_receive_validation = False
-
-    def disable_receive_validation(self):
-        """
-        Disable validation for the message reception.
-
-        N.B. This is a temporary workaround specifically designed to bypass bugs in Astarte core.
-             It should not be used carelessly.
-
-        See: https://github.com/astarte-platform/astarte-device-sdk-python/issues/136
-        """
-        self._disable_receive_validation = True
 
     @abstractmethod
     def add_interface_from_json(self, interface_json: dict):
@@ -442,7 +430,7 @@ class Device(ABC):
             return
 
         # Check the payload matches with the interface
-        if payload and not self._disable_receive_validation:
+        if payload:
             try:
                 interface.validate_payload(path, payload)
             except ValidationError as val_err:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -642,33 +642,6 @@ class TestMyAbstract(unittest.TestCase):
 
     @mock.patch.multiple(Device, __abstractmethods__=set(), _store_property=mock.DEFAULT)
     @mock.patch.object(Introspection, "get_interface")
-    def test_device_on_message_generic_no_validation(self, mock_get_interface, _store_property):
-        device = Device()
-        device.disable_receive_validation()
-
-        on_data_received_mock = mock.MagicMock()
-        device.set_events_callbacks(on_data_received=on_data_received_mock)
-        interface_name = "interface name"
-        interface_path = "interface path"
-        mock_message = mock.MagicMock()
-        device._on_message_generic(interface_name, interface_path, mock_message)
-
-        mock_get_interface.assert_called_once_with(interface_name)
-        mock_get_interface.return_value.is_server_owned.assert_called_once()
-        mock_get_interface.return_value.is_property_endpoint_resettable.assert_not_called()
-        mock_get_interface.return_value.validate_path.assert_called_once_with(
-            interface_path, mock_message
-        )
-        mock_get_interface.return_value.validate_payload.assert_not_called()
-        _store_property.assert_called_once_with(
-            mock_get_interface.return_value, interface_path, mock_message
-        )
-        on_data_received_mock.assert_called_once_with(
-            device, interface_name, interface_path, mock_message
-        )
-
-    @mock.patch.multiple(Device, __abstractmethods__=set(), _store_property=mock.DEFAULT)
-    @mock.patch.object(Introspection, "get_interface")
     def test_device_on_message_generic_with_threading(self, mock_get_interface, _store_property):
         device = Device()
 


### PR DESCRIPTION
This PR is dependent on the updates present in the release branch. Wait for a forward port before merging.